### PR TITLE
Increased max frequency during charging

### DIFF
--- a/configs/thermal-engine-8996.conf
+++ b/configs/thermal-engine-8996.conf
@@ -9,7 +9,7 @@ sampling         5000
 device           cpu_voltage
 set_point        40000
 set_point_clr    38500
-device_perf_floor 1036800
+device_perf_floor 1136800
 
 [SS-CPUS-ALL]
 algo_type        ss


### PR DESCRIPTION
Change it from the default and added 100mhz more the device is charging thus it won't be a large problem.

You can add a few more but I would recommend only till about 800mhz extra